### PR TITLE
Workaround GitHub Pagination for releases

### DIFF
--- a/github.go
+++ b/github.go
@@ -22,7 +22,12 @@ func latestRelease(artefact, owner, repo string, desired *string) (*release, err
 
 	client := github.NewClient(nil)
 
-	releases, _, err := client.Repositories.ListReleases(context.Background(), owner, repo, &github.ListOptions{})
+	releases, _, err := client.Repositories.ListReleases(context.Background(), owner, repo, &github.ListOptions{
+		// defaults to 15, but we want to ensure we get enough releases
+		// 50 is reasonably large enough to not miss any releases
+		// in case we do, please refactor it yourself :)
+		PerPage: 50,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Not a real fix, but fast and close enough workaround
Fixes  #14

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
